### PR TITLE
Add svelte-intl-precompile to the supported Svelte frameworks

### DIFF
--- a/src/frameworks/svelte.ts
+++ b/src/frameworks/svelte.ts
@@ -11,6 +11,7 @@ class SvelteFramework extends Framework {
   detection= {
     packageJSON: [
       'svelte-i18n',
+      'svelte-intl-precompile',
     ],
   }
 


### PR DESCRIPTION
The API is identical to to svelte-i18n so it's probably not worth adding more fixtures for this.